### PR TITLE
Use more secure Maven repo url

### DIFF
--- a/endless/build.gradle
+++ b/endless/build.gradle
@@ -14,7 +14,7 @@ group 'com.commonsware.cwac'
 
 repositories {
     maven {
-        url "https://repo.commonsware.com.s3.amazonaws.com"
+        url "https://s3.amazonaws.com/repo.commonsware.com"
     }
 }
 


### PR DESCRIPTION
Fixes repository URL -- Amazon's SSL cert only signs for `*.s3.amazonaws.com` with one prefix, while `s3.amazonaws.com/*` is still signed.