### PR TITLE
Define android gradle plugin by extensions value

### DIFF
--- a/endless/build.gradle
+++ b/endless/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath "com.android.tools.build:gradle:$rootProject.ext.androidGradlePlugin"
     }
 }
 


### PR DESCRIPTION
- [x] CR @brandonchinn 

Define `androidGradlePlugin` like this in the parent project's build.gradle and the android gradle plugin should stay in sync for each subproject.

```groovy
ext {
    androidGradlePlugin = "2.2.0"
}
```